### PR TITLE
Prevent generating Jbuilder files when not specifying `-e jbuilder` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or specify the template engine by:
 $ rails g rambulance:install -e slim
 ```
 
-Rambulance now support `erb`, `haml`, `slim` template engines, if you don't specify the `-e` option, erb will be used as default.
+Rambulance now support `erb`, `haml`, `slim`, `jbuilder` template engines, if you don't specify the `-e` option, erb will be used as default.
 
 Now you can start editing templates like `app/views/errors/not_found.html.erb`. Edit, run `rails server` and open [`localhost:3000/rambulance/not_found`](http://localhost:3000/rambulance/not_found)!
 

--- a/lib/generators/rambulance/install_generator.rb
+++ b/lib/generators/rambulance/install_generator.rb
@@ -24,12 +24,7 @@ BANNER
       desc ''
       def copy_templates #:nodoc:
         say "generating templates:"
-        filename_pattern = File.join(self.class.source_root, "views", "*.html.#{template_engine}")
-        Dir.glob(filename_pattern).map {|f| File.basename f }.each do |f|
-          copy_file "views/#{f}", "app/views/errors/#{f}"
-        end
-
-        filename_pattern = File.join(self.class.source_root, "views", "*.json.jbuilder")
+        filename_pattern = File.join(self.class.source_root, "views", "*#{file_extname}")
         Dir.glob(filename_pattern).map {|f| File.basename f }.each do |f|
           copy_file "views/#{f}", "app/views/errors/#{f}"
         end
@@ -59,6 +54,15 @@ BANNER
 
       def longest_error_name_size
         ActionDispatch::ExceptionWrapper.rescue_responses.keys.sort_by(&:size).last.size
+      end
+
+      def file_extname
+        case template_engine
+        when "jbuilder"
+          ".json.jbuilder"
+        else
+          ".html.#{template_engine}"
+        end
       end
     end
   end


### PR DESCRIPTION
When I executed `rails g rambulance:install -e haml`, Rambulance generated Haml files but also Jbuilder files.
I think it should generate only Haml files when specified `-e haml` option.
So I tried to fix it.