### PR TITLE
Fix master build

### DIFF
--- a/gemfiles/rails_32.gemfile
+++ b/gemfiles/rails_32.gemfile
@@ -6,5 +6,6 @@ gem "activesupport", "~> 3.2.0"
 gem "actionpack", "~> 3.2.0"
 gem "railties", "~> 3.2.0"
 gem 'jbuilder', '2.2.13'
+gem 'mime-types', '~> 2.9', platforms: :ruby_19
 
 gemspec :path => "../"

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -6,5 +6,6 @@ gem "activesupport", "~> 4.0.0"
 gem "actionpack", "~> 4.0.0"
 gem "railties", "~> 4.0.0"
 gem "test-unit" if RUBY_VERSION >= "2.2.0"
+gem 'mime-types', '~> 2.9', platforms: :ruby_19
 
 gemspec :path => "../"

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "activesupport", "~> 4.1.0"
 gem "actionpack", "~> 4.1.0"
 gem "railties", "~> 4.1.0"
+gem 'mime-types', '~> 2.9', platforms: :ruby_19
 
 gemspec :path => "../"

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -6,5 +6,6 @@ gem "activesupport", "~> 4.2.0"
 gem "actionpack", "~> 4.2.0"
 gem "railties", "~> 4.2.0"
 gem "minitest", "~> 5.3.4"
+gem 'mime-types', '~> 2.9', platforms: :ruby_19
 
 gemspec :path => "../"


### PR DESCRIPTION
Hi.

mime-types 3.0 drop support for Ruby 1.9.
So locked so as to use mime-types 2.9.x in Ruby 1.9.