### PR TITLE
Fix helper can't be used in rambulance templates

### DIFF
--- a/lib/rambulance/railtie.rb
+++ b/lib/rambulance/railtie.rb
@@ -1,6 +1,6 @@
 module Rambulance
   class Railtie < Rails::Railtie
-    initializer 'rambulance' do |app|
+    initializer 'rambulance', after: :prepend_helpers_path do |app|
       require "rambulance/exceptions_app"
 
       app.config.exceptions_app =

--- a/spec/fake_app/app/helpers/application_helper.rb
+++ b/spec/fake_app/app/helpers/application_helper.rb
@@ -1,0 +1,5 @@
+module ApplicationHelper
+  def forbidden
+    'Forbidden.'
+  end
+end

--- a/spec/fake_app/app/views/errors/forbidden.html.erb
+++ b/spec/fake_app/app/views/errors/forbidden.html.erb
@@ -1,0 +1,1 @@
+<%= forbidden %>

--- a/spec/fake_app/rails_app.rb
+++ b/spec/fake_app/rails_app.rb
@@ -1,5 +1,3 @@
-require 'action_controller/railtie'
-require 'action_view/railtie'
 require 'jbuilder'
 
 # config
@@ -22,12 +20,14 @@ end
 
 # custom exception class
 class CustomException < StandardError; end
+class ForbiddenException < StandardError; end
 
 Rambulance.setup do |config|
   config.layout_name = "error"
   config.rescue_responses = {
     'TypeError'       => :bad_request,
-    'CustomException' => :not_found
+    'CustomException' => :not_found,
+    'ForbiddenException' => :forbidden
   }
 end
 
@@ -56,7 +56,8 @@ class UsersController < ApplicationController
   end
 
   def create; end
-end
 
-# helpers
-Object.const_set(:ApplicationHelper, Module.new)
+  def edit
+    raise ForbiddenException
+  end
+end

--- a/spec/requests/error_page_spec.rb
+++ b/spec/requests/error_page_spec.rb
@@ -56,6 +56,14 @@ feature 'Error page' do
       expect(page.body).to have_content "Page not found."
     end
 
+    scenario 'displays 403 page due to ForbiddenException' do
+      visit '/users/1/edit'
+
+      expect(page.status_code).to eq(403)
+      expect(page.body).to have_content "Error page"
+      expect(page.body).to have_content "Forbidden."
+    end
+
     context "with a custom layout name" do
       before do
         @org, Rambulance.layout_name = Rambulance.layout_name, "application"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'rails'
-
+require 'action_controller/railtie'
+require 'action_view/railtie'
 require 'bundler/setup'
 Bundler.require
 


### PR DESCRIPTION
Using helper methods raise error in rambulance template, because 
`ExceptionsApp` has no helpers.
If a controller is loaded before running `prepend_helpers_path` initializer , it has no helpers.

So I changed order of initializers.