### PR TITLE
Add missing unprocessable_entity action to ExceptionsApp template

### DIFF
--- a/lib/generators/rambulance/templates/exceptions_app.rb
+++ b/lib/generators/rambulance/templates/exceptions_app.rb
@@ -5,9 +5,12 @@ class ExceptionsApp < Rambulance::ExceptionsApp
   def forbidden
   end
 
+  def internal_server_error
+  end
+
   def not_found
   end
 
-  def internal_server_error
+  def unprocessable_entity
   end
 end


### PR DESCRIPTION
Add missing `unprocessable_entity` action to `ExceptionsApp` template in order to handle unprocessable_entity exception.

## Changes

- Add unprocessable_entity action
- Make actions alphabetical