### PR TITLE
Stop to affect other h1 style

### DIFF
--- a/lib/generators/rambulance/templates/views/bad_request.html.erb
+++ b/lib/generators/rambulance/templates/views/bad_request.html.erb
@@ -22,7 +22,7 @@
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
-  h1 {
+  div.dialog h1 {
     font-size: 100%;
     color: #730E15;
     line-height: 1.5em;

--- a/lib/generators/rambulance/templates/views/forbidden.html.erb
+++ b/lib/generators/rambulance/templates/views/forbidden.html.erb
@@ -22,7 +22,7 @@
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
-  h1 {
+  div.dialog h1 {
     font-size: 100%;
     color: #730E15;
     line-height: 1.5em;

--- a/lib/generators/rambulance/templates/views/internal_server_error.html.erb
+++ b/lib/generators/rambulance/templates/views/internal_server_error.html.erb
@@ -22,7 +22,7 @@
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
-  h1 {
+  div.dialog h1 {
     font-size: 100%;
     color: #730E15;
     line-height: 1.5em;

--- a/lib/generators/rambulance/templates/views/not_found.html.erb
+++ b/lib/generators/rambulance/templates/views/not_found.html.erb
@@ -22,7 +22,7 @@
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
-  h1 {
+  div.dialog h1 {
     font-size: 100%;
     color: #730E15;
     line-height: 1.5em;

--- a/lib/generators/rambulance/templates/views/unprocessable_entity.html.erb
+++ b/lib/generators/rambulance/templates/views/unprocessable_entity.html.erb
@@ -22,7 +22,7 @@
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
-  h1 {
+  div.dialog h1 {
     font-size: 100%;
     color: #730E15;
     line-height: 1.5em;


### PR DESCRIPTION
The `h1` style affects other `h1` tags. (eg, `layouts/error.html.erb`'s `h1` tag)