### PR TITLE
fixes #58 handle ActionDispatch::Http::Parameters::ParseError

### DIFF
--- a/lib/rambulance/exceptions_app.rb
+++ b/lib/rambulance/exceptions_app.rb
@@ -69,7 +69,7 @@ module Rambulance
 
       begin
         request.POST
-      rescue ActionController::BadRequest
+      rescue ActionController::BadRequest, ActionDispatch::Http::Parameters::ParseError
         request.env["MALFORMED_BODY"], request.env["rack.input"] = request.env["rack.input"], StringIO.new
       end
 

--- a/test/requests/error_json_test.rb
+++ b/test/requests/error_json_test.rb
@@ -74,6 +74,17 @@ class ErrorJsonTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'returns an appropriate status when JSON data is malformed' do
+    if Rails::VERSION::STRING >= '5.1.0'
+      post '/unknown/path', params: 'x', headers: { "CONTENT_TYPE" => "application/json" }
+    else
+      post '/unknown/path', 'x', "CONTENT_TYPE" => "application/json"
+    end
+
+    assert_equal 404, response.status
+  end
+
+
   private
 
   def without_layouts


### PR DESCRIPTION
* when a request contains unparsable JSON, it would fail with a 500
  with ActionDispatch::Http::Parameters::ParseError even before
  evaluating routes
* created a test that reproduces this error (returned 500 instead of
  404)
* catching this error early, and the test is now green