### PR TITLE
Add the ability to precompile error pages on asset precompile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tmp
 *.a
 mkmf.log
 *.log
+test/fake_app/public/*.html

--- a/lib/rambulance/exceptions_app.rb
+++ b/lib/rambulance/exceptions_app.rb
@@ -45,6 +45,19 @@ module Rambulance
       [Rambulance.view_path]
     end
 
+    def self.precompile!(env: {}, assigns: {})
+      ERROR_HTTP_STATUSES.each do |http_status, status_in_words|
+        begin
+          html = renderer.new(env).render(status_in_words, assigns: assigns)
+          path = Rails.public_path.join("#{http_status}.html").to_s
+
+          File.write(path, html)
+        rescue ActionView::MissingTemplate
+          Rails.logger.info "Template for #{http_status}(#{status_in_words}) does not exist. Skiping..."
+        end
+      end
+    end
+
     ERROR_HTTP_STATUSES.values.each do |status_in_words|
       eval <<-ACTION, nil, __FILE__, __LINE__ + 1
         def #{status_in_words}

--- a/lib/rambulance/railtie.rb
+++ b/lib/rambulance/railtie.rb
@@ -1,5 +1,8 @@
 module Rambulance
   class Railtie < Rails::Railtie
+    config.rambulance = ActiveSupport::OrderedOptions.new
+    config.rambulance.static_error_pages = false
+
     initializer 'rambulance', after: :prepend_helpers_path do |app|
       ActiveSupport.on_load(:action_controller) do
         require "rambulance/exceptions_app"
@@ -31,6 +34,16 @@ module Rambulance
         Rails.application.routes.append do
           mount app.config.exceptions_app, at: '/rambulance'
         end if Rails.env.development?
+      end
+    end
+
+    rake_tasks do
+      require 'rambulance/exceptions_app'
+
+      if config.rambulance.static_error_pages
+        Rake::Task["assets:precompile"].enhance do
+          Rake::Task["rambulance:precompile"].invoke
+        end
       end
     end
   end

--- a/lib/tasks/rambulance.rake
+++ b/lib/tasks/rambulance.rake
@@ -1,0 +1,12 @@
+namespace :rambulance do
+  desc "Precompiles static HTML files for each error status"
+  task precompile: :environment do
+    exceptions_app = begin
+                       ::ExceptionsApp
+                     rescue NameError
+                       Rambulance::ExceptionsApp
+                     end
+
+    exceptions_app.precompile!
+  end
+end

--- a/test/exceptions_app_test.rb
+++ b/test/exceptions_app_test.rb
@@ -2,8 +2,23 @@ require 'test_helper'
 
 class ExeptionsAppTest < ActionDispatch::IntegrationTest
   test 'returns 404 for unknown format for pages that do not exist' do
-    get '/does_not_exist', headers: { 'Accept' => '*/*'  }
+    get '/does_not_exist', headers: { 'Accept' => '*/*' }
 
     assert_equal 404, response.status
+  end
+
+  test '#precompile! generates static HTML files for each error status' do
+    Dir[Rails.public_path.join("*.html")].each do |file|
+      File.delete(file)
+    end
+
+    Rambulance::ExceptionsApp.precompile!
+
+    assert File.exist?(Rails.public_path.join("400.html"))
+    assert File.exist?(Rails.public_path.join("403.html"))
+    assert File.exist?(Rails.public_path.join("404.html"))
+    assert File.exist?(Rails.public_path.join("406.html"))
+    assert File.exist?(Rails.public_path.join("500.html"))
+    assert_not File.exist?(Rails.public_path.join("401.html"))
   end
 end


### PR DESCRIPTION
Often times dynamically generating error pages is risky, but it’s not always necessary to do that when the error page does not depend on e.g. authentication information to render the whole page. What’s more important when it comes to building an error page is to use the same assets across the main app and the static pages. In such a case, we should be able to generate error pages at the time of asset pre-completion, rather than doing so at runtime.

# Todos

 * [ ] Update README.
 * [ ] Drop support for Rails 4.2? It doesn’t have support for the controller renderer.
 * [ ] Add more test converage around the `static_error_pages = true/false`.