### PR TITLE
Improve Bad Request handling

### DIFF
--- a/lib/rambulance/exceptions_app.rb
+++ b/lib/rambulance/exceptions_app.rb
@@ -80,6 +80,7 @@ module Rambulance
       begin
         request.POST
       rescue *BAD_REQUEST_ERRORS
+        request.env["action_dispatch.request.request_parameters"] = {}
         request.env["MALFORMED_BODY"], request.env["rack.input"] = request.env["rack.input"], StringIO.new
       end
 


### PR DESCRIPTION
If you try and use `request.format = :json` in the exceptions app, you'll cause the original parsing error to be re-raised.

`Error during failsafe response: Error occurred while parsing request parameters`

I created this PR with a potential fix, but wasn't sure if this was the best way to handle this. When requests come from our API, we want to force the response in JSON which is why we explicitly call `request.format = :json`.

```ruby
class ExceptionsApp < Rambulance::ExceptionsApp

  def bad_request
    handle_error
  end

  def forbidden
    handle_error
  end

  def internal_server_error
    handle_error
  end

  def not_found
    handle_error
  end

  def unprocessable_entity
    handle_error
  end

  private

  def handle_error
    # force render JSON for API hosts
    request.format = :json if request.host.in?(Hosts.all_apis)

    respond_to do |format|
      format.json { render 'error' }
      format.turbo_stream { render 'error' }
      format.html { render 'error' }
    end
  end

end
```