### PR TITLE
Use the latest version of minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in rambulance.gemspec
 gemspec
-gem 'minitest', '< 5.25.0'
+
+gem 'minitest'

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "minitest", "< 5.25.0"
+gem "minitest"
 gem "activesupport", "~> 7.0.0"
 gem "actionpack", "~> 7.0.0"
 gem "railties", "~> 7.0.0"

--- a/gemfiles/rails_71.gemfile
+++ b/gemfiles/rails_71.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "minitest", "< 5.25.0"
+gem "minitest"
 gem "activesupport", "~> 7.1.0"
 gem "actionpack", "~> 7.1.0"
 gem "railties", "~> 7.1.0"

--- a/gemfiles/rails_72.gemfile
+++ b/gemfiles/rails_72.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "minitest", "< 5.25.0"
+gem "minitest"
 gem "activesupport", "~> 7.2.0"
 gem "actionpack", "~> 7.2.0"
 gem "railties", "~> 7.2.0"

--- a/gemfiles/rails_80.gemfile
+++ b/gemfiles/rails_80.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "minitest", "< 5.25.0"
+gem "minitest"
 gem "activesupport", "~> 8.0.0"
 gem "actionpack", "~> 8.0.0"
 gem "railties", "~> 8.0.0"

--- a/gemfiles/rails_81.gemfile
+++ b/gemfiles/rails_81.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "minitest", "< 5.25.0"
+gem "minitest"
 gem "activesupport", "~> 8.1.0"
 gem "actionpack", "~> 8.1.0"
 gem "railties", "~> 8.1.0"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -8,6 +8,6 @@ git "https://github.com/rails/rails.git" do
   gem "railties"
 end
 
-gem "minitest", "< 5.25.0"
+gem "minitest"
 
 gemspec path: "../"


### PR DESCRIPTION
Addresses the warning in the test:

```
/home/runner/work/rambulance/rambulance/vendor/bundle/ruby/3.4.0/gems/minitest-5.24.1/lib/minitest/mock.rb:33: warning: redefining 'object_id' may cause serious problems
```